### PR TITLE
Short circuit if no paths are available in an event.

### DIFF
--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -271,6 +271,10 @@ impl<T: FileIdCache> DebounceDataInner<T> {
             return;
         }
 
+        if event.paths.is_empty() {
+            log::warn!("add_event: Skipping event with empty paths array");
+            return;
+        }
         let path = &event.paths[0];
 
         match &event.kind {


### PR DESCRIPTION
On Linux, the INotifyWatcher can create events that have no paths associated. This caused a panic.

For now, ignore these events.