### PR TITLE
Add watcher filter

### DIFF
--- a/notify-debouncer-full/src/lib.rs
+++ b/notify-debouncer-full/src/lib.rs
@@ -88,7 +88,8 @@ pub use notify_types::debouncer_full::DebouncedEvent;
 use file_id::FileId;
 use notify::{
     event::{ModifyKind, RemoveKind, RenameMode},
-    Error, ErrorKind, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher, WatcherKind,
+    Error, ErrorKind, Event, EventKind, RecommendedWatcher, RecursiveMode, WatchFilter, Watcher,
+    WatcherKind,
 };
 
 /// The set of requirements for watcher debounce event handling functions.
@@ -580,7 +581,17 @@ impl<T: Watcher, C: FileIdCache> Debouncer<T, C> {
         path: impl AsRef<Path>,
         recursive_mode: RecursiveMode,
     ) -> notify::Result<()> {
-        self.watcher.watch(path.as_ref(), recursive_mode)?;
+        self.watch_filtered(path, recursive_mode, WatchFilter::accept_all())
+    }
+
+    pub fn watch_filtered(
+        &mut self,
+        path: impl AsRef<Path>,
+        recursive_mode: RecursiveMode,
+        watch_filter: WatchFilter,
+    ) -> notify::Result<()> {
+        self.watcher
+            .watch_filtered(path.as_ref(), recursive_mode, watch_filter)?;
         self.add_root(path.as_ref(), recursive_mode);
         Ok(())
     }

--- a/notify/src/fsevent.rs
+++ b/notify/src/fsevent.rs
@@ -537,7 +537,7 @@ unsafe fn callback_impl(
 
         let mut handle_event = false;
         for (p, (r, filt)) in &(*info).recursive_info {
-            if path.starts_with(p) && filt.should_watch(p) {
+            if path.starts_with(p) && filt.should_watch(&path) {
                 if *r || &path == p {
                     handle_event = true;
                     break;

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -443,6 +443,9 @@ impl EventLoop {
         watch_self: bool,
         watch_filter: WatchFilter,
     ) -> Result<()> {
+        if !watch_filter.should_watch(&path) {
+            return Ok(());
+        }
         let mut watchmask = WatchMask::ATTRIB
             | WatchMask::CREATE
             | WatchMask::OPEN

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -5,7 +5,9 @@
 //! will return events for the directory itself, and for files inside the directory.
 
 use super::event::*;
-use super::{Config, Error, ErrorKind, EventHandler, RecursiveMode, Result, Watcher};
+use super::{
+    Config, Error, ErrorKind, EventHandler, RecursiveMode, Result, WatchFilterFn, Watcher,
+};
 use crate::{bounded, unbounded, BoundSender, Receiver, Sender};
 use inotify as inotify_sys;
 use inotify_sys::{EventMask, Inotify, WatchDescriptor, WatchMask};
@@ -51,7 +53,12 @@ pub struct INotifyWatcher {
 }
 
 enum EventLoopMsg {
-    AddWatch(PathBuf, RecursiveMode, Sender<Result<()>>),
+    AddWatch(
+        PathBuf,
+        RecursiveMode,
+        Box<WatchFilterFn>,
+        Sender<Result<()>>,
+    ),
     RemoveWatch(PathBuf, Sender<Result<()>>),
     Shutdown,
     Configure(Config, BoundSender<Result<bool>>),
@@ -172,8 +179,13 @@ impl EventLoop {
     fn handle_messages(&mut self) {
         while let Ok(msg) = self.event_loop_rx.try_recv() {
             match msg {
-                EventLoopMsg::AddWatch(path, recursive_mode, tx) => {
-                    let _ = tx.send(self.add_watch(path, recursive_mode.is_recursive(), true));
+                EventLoopMsg::AddWatch(path, recursive_mode, watch_filter, tx) => {
+                    let _ = tx.send(self.add_watch(
+                        path,
+                        recursive_mode.is_recursive(),
+                        true,
+                        &watch_filter,
+                    ));
                 }
                 EventLoopMsg::RemoveWatch(path, tx) => {
                     let _ = tx.send(self.remove_watch(path, false));
@@ -392,11 +404,17 @@ impl EventLoop {
         }
 
         for path in add_watches {
-            self.add_watch(path, true, false).ok();
+            self.add_watch(path, true, false, &|_| true).ok();
         }
     }
 
-    fn add_watch(&mut self, path: PathBuf, is_recursive: bool, mut watch_self: bool) -> Result<()> {
+    fn add_watch(
+        &mut self,
+        path: PathBuf,
+        is_recursive: bool,
+        mut watch_self: bool,
+        watch_filter: &dyn Fn(&Path) -> bool,
+    ) -> Result<()> {
         // If the watch is not recursive, or if we determine (by stat'ing the path to get its
         // metadata) that the watched path is not a directory, add a single path watch.
         if !is_recursive || !metadata(&path).map_err(Error::io_watch)?.is_dir() {
@@ -407,6 +425,7 @@ impl EventLoop {
             .follow_links(self.follow_links)
             .into_iter()
             .filter_map(filter_dir)
+            .filter(|e| watch_filter(e.path()))
         {
             self.add_single_watch(entry.path().to_path_buf(), is_recursive, watch_self)?;
             watch_self = false;
@@ -541,7 +560,12 @@ impl INotifyWatcher {
         Ok(INotifyWatcher { channel, waker })
     }
 
-    fn watch_inner(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+    fn watch_inner(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: Box<WatchFilterFn>,
+    ) -> Result<()> {
         let pb = if path.is_absolute() {
             path.to_owned()
         } else {
@@ -549,7 +573,7 @@ impl INotifyWatcher {
             p.join(path)
         };
         let (tx, rx) = unbounded();
-        let msg = EventLoopMsg::AddWatch(pb, recursive_mode, tx);
+        let msg = EventLoopMsg::AddWatch(pb, recursive_mode, watch_filter, tx);
 
         // we expect the event loop to live and reply => unwraps must not panic
         self.channel.send(msg).unwrap();
@@ -580,8 +604,13 @@ impl Watcher for INotifyWatcher {
         Self::from_event_handler(Box::new(event_handler), config.follow_symlinks())
     }
 
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
-        self.watch_inner(path, recursive_mode)
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: Box<WatchFilterFn>,
+    ) -> Result<()> {
+        self.watch_inner(path, recursive_mode, watch_filter)
     }
 
     fn unwatch(&mut self, path: &Path) -> Result<()> {

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -443,9 +443,6 @@ impl EventLoop {
         watch_self: bool,
         watch_filter: WatchFilter,
     ) -> Result<()> {
-        if !watch_filter.should_watch(&path) {
-            return Ok(());
-        }
         let mut watchmask = WatchMask::ATTRIB
             | WatchMask::CREATE
             | WatchMask::OPEN

--- a/notify/src/inotify.rs
+++ b/notify/src/inotify.rs
@@ -5,9 +5,7 @@
 //! will return events for the directory itself, and for files inside the directory.
 
 use super::event::*;
-use super::{
-    Config, Error, ErrorKind, EventHandler, RecursiveMode, Result, WatchFilterFn, Watcher,
-};
+use super::{Config, Error, ErrorKind, EventHandler, RecursiveMode, Result, WatchFilter, Watcher};
 use crate::{bounded, unbounded, BoundSender, Receiver, Sender};
 use inotify as inotify_sys;
 use inotify_sys::{EventMask, Inotify, WatchDescriptor, WatchMask};
@@ -39,7 +37,7 @@ struct EventLoop {
     inotify: Option<Inotify>,
     event_handler: Box<dyn EventHandler>,
     /// PathBuf -> (WatchDescriptor, WatchMask, is_recursive, is_dir)
-    watches: HashMap<PathBuf, (WatchDescriptor, WatchMask, bool, bool)>,
+    watches: HashMap<PathBuf, (WatchDescriptor, WatchMask, bool, bool, WatchFilter)>,
     paths: HashMap<WatchDescriptor, PathBuf>,
     rename_event: Option<Event>,
     follow_links: bool,
@@ -53,12 +51,7 @@ pub struct INotifyWatcher {
 }
 
 enum EventLoopMsg {
-    AddWatch(
-        PathBuf,
-        RecursiveMode,
-        Box<WatchFilterFn>,
-        Sender<Result<()>>,
-    ),
+    AddWatch(PathBuf, RecursiveMode, WatchFilter, Sender<Result<()>>),
     RemoveWatch(PathBuf, Sender<Result<()>>),
     Shutdown,
     Configure(Config, BoundSender<Result<bool>>),
@@ -68,15 +61,15 @@ enum EventLoopMsg {
 fn add_watch_by_event(
     path: &Option<PathBuf>,
     event: &inotify_sys::Event<&OsStr>,
-    watches: &HashMap<PathBuf, (WatchDescriptor, WatchMask, bool, bool)>,
-    add_watches: &mut Vec<PathBuf>,
+    watches: &HashMap<PathBuf, (WatchDescriptor, WatchMask, bool, bool, WatchFilter)>,
+    add_watches: &mut Vec<(PathBuf, WatchFilter)>,
 ) {
     if let Some(ref path) = *path {
         if event.mask.contains(EventMask::ISDIR) {
             if let Some(parent_path) = path.parent() {
-                if let Some(&(_, _, is_recursive, _)) = watches.get(parent_path) {
+                if let Some(&(_, _, is_recursive, _, ref filter)) = watches.get(parent_path) {
                     if is_recursive {
-                        add_watches.push(path.to_owned());
+                        add_watches.push((path.to_owned(), filter.clone()));
                     }
                 }
             }
@@ -87,7 +80,7 @@ fn add_watch_by_event(
 #[inline]
 fn remove_watch_by_event(
     path: &Option<PathBuf>,
-    watches: &HashMap<PathBuf, (WatchDescriptor, WatchMask, bool, bool)>,
+    watches: &HashMap<PathBuf, (WatchDescriptor, WatchMask, bool, bool, WatchFilter)>,
     remove_watches: &mut Vec<PathBuf>,
 ) {
     if let Some(ref path) = *path {
@@ -184,7 +177,7 @@ impl EventLoop {
                         path,
                         recursive_mode.is_recursive(),
                         true,
-                        &watch_filter,
+                        watch_filter,
                     ));
                 }
                 EventLoopMsg::RemoveWatch(path, tx) => {
@@ -319,8 +312,8 @@ impl EventLoop {
                                     Some(watched_path) => {
                                         let current_watch = self.watches.get(watched_path);
                                         match current_watch {
-                                            Some(&(_, _, _, true)) => RemoveKind::Folder,
-                                            Some(&(_, _, _, false)) => RemoveKind::File,
+                                            Some(&(_, _, _, true, _)) => RemoveKind::Folder,
+                                            Some(&(_, _, _, false, _)) => RemoveKind::File,
                                             None => RemoveKind::Other,
                                         }
                                     }
@@ -403,8 +396,8 @@ impl EventLoop {
             self.remove_watch(path, true).ok();
         }
 
-        for path in add_watches {
-            self.add_watch(path, true, false, &|_| true).ok();
+        for (path, filter) in add_watches {
+            self.add_watch(path, true, false, filter).ok();
         }
     }
 
@@ -413,21 +406,30 @@ impl EventLoop {
         path: PathBuf,
         is_recursive: bool,
         mut watch_self: bool,
-        watch_filter: &dyn Fn(&Path) -> bool,
+        watch_filter: WatchFilter,
     ) -> Result<()> {
+        if !watch_filter.should_watch(&path) {
+            return Ok(());
+        }
+
         // If the watch is not recursive, or if we determine (by stat'ing the path to get its
         // metadata) that the watched path is not a directory, add a single path watch.
         if !is_recursive || !metadata(&path).map_err(Error::io_watch)?.is_dir() {
-            return self.add_single_watch(path, false, true);
+            return self.add_single_watch(path, false, true, WatchFilter::accept_all());
         }
 
         for entry in WalkDir::new(path)
             .follow_links(self.follow_links)
             .into_iter()
             .filter_map(filter_dir)
-            .filter(|e| watch_filter(e.path()))
+            .filter(|e| watch_filter.should_watch(e.path()))
         {
-            self.add_single_watch(entry.path().to_path_buf(), is_recursive, watch_self)?;
+            self.add_single_watch(
+                entry.path().to_path_buf(),
+                is_recursive,
+                watch_self,
+                watch_filter.clone(),
+            )?;
             watch_self = false;
         }
 
@@ -439,6 +441,7 @@ impl EventLoop {
         path: PathBuf,
         is_recursive: bool,
         watch_self: bool,
+        watch_filter: WatchFilter,
     ) -> Result<()> {
         let mut watchmask = WatchMask::ATTRIB
             | WatchMask::CREATE
@@ -454,7 +457,7 @@ impl EventLoop {
             watchmask.insert(WatchMask::MOVE_SELF);
         }
 
-        if let Some(&(_, old_watchmask, _, _)) = self.watches.get(&path) {
+        if let Some(&(_, old_watchmask, _, _, _)) = self.watches.get(&path) {
             watchmask.insert(old_watchmask);
             watchmask.insert(WatchMask::MASK_ADD);
         }
@@ -475,8 +478,16 @@ impl EventLoop {
                 Ok(w) => {
                     watchmask.remove(WatchMask::MASK_ADD);
                     let is_dir = metadata(&path).map_err(Error::io)?.is_dir();
-                    self.watches
-                        .insert(path.clone(), (w.clone(), watchmask, is_recursive, is_dir));
+                    self.watches.insert(
+                        path.clone(),
+                        (
+                            w.clone(),
+                            watchmask,
+                            is_recursive,
+                            is_dir,
+                            watch_filter.clone(),
+                        ),
+                    );
                     self.paths.insert(w, path);
                     Ok(())
                 }
@@ -489,7 +500,7 @@ impl EventLoop {
     fn remove_watch(&mut self, path: PathBuf, remove_recursive: bool) -> Result<()> {
         match self.watches.remove(&path) {
             None => return Err(Error::watch_not_found().add_path(path)),
-            Some((w, _, is_recursive, _)) => {
+            Some((w, _, is_recursive, _, _)) => {
                 if let Some(ref mut inotify) = self.inotify {
                     let mut inotify_watches = inotify.watches();
                     log::trace!("removing inotify watch: {}", path.display());
@@ -564,7 +575,7 @@ impl INotifyWatcher {
         &mut self,
         path: &Path,
         recursive_mode: RecursiveMode,
-        watch_filter: Box<WatchFilterFn>,
+        watch_filter: WatchFilter,
     ) -> Result<()> {
         let pb = if path.is_absolute() {
             path.to_owned()
@@ -608,7 +619,7 @@ impl Watcher for INotifyWatcher {
         &mut self,
         path: &Path,
         recursive_mode: RecursiveMode,
-        watch_filter: Box<WatchFilterFn>,
+        watch_filter: WatchFilter,
     ) -> Result<()> {
         self.watch_inner(path, recursive_mode, watch_filter)
     }

--- a/notify/src/kqueue.rs
+++ b/notify/src/kqueue.rs
@@ -6,7 +6,7 @@
 
 use super::event::*;
 use super::{Config, Error, EventHandler, RecursiveMode, Result, Watcher};
-use crate::{unbounded, Receiver, Sender};
+use crate::{unbounded, Receiver, Sender, WatchFilter};
 use kqueue::{EventData, EventFilter, FilterFlag, Ident};
 use std::collections::HashMap;
 use std::env;
@@ -435,7 +435,12 @@ impl Watcher for KqueueWatcher {
         Self::from_event_handler(Box::new(event_handler), config.follow_symlinks())
     }
 
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        _watch_filter: WatchFilter,
+    ) -> Result<()> {
         self.watch_inner(path, recursive_mode)
     }
 

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -287,6 +287,8 @@ pub enum WatcherKind {
     NullWatcher,
 }
 
+type WatchFilterFn = dyn Fn(&Path) -> bool + Send;
+
 /// Type that can deliver file activity notifications
 ///
 /// `Watcher` is implemented per platform using the best implementation available on that platform.
@@ -312,7 +314,31 @@ pub trait Watcher {
     ///
     /// [#165]: https://github.com/notify-rs/notify/issues/165
     /// [#166]: https://github.com/notify-rs/notify/issues/166
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()>;
+    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+        self.watch_filtered(path, recursive_mode, Box::new(|_| true))
+    }
+
+    /// Begin watching a new path, filtering out sub-paths by name.
+    ///
+    /// If the `path` is a directory, `recursive_mode` will be evaluated. If `recursive_mode` is
+    /// `RecursiveMode::Recursive` events will be delivered for all files in that tree. Otherwise
+    /// only the directory and its immediate children will be watched.
+    ///
+    /// If the `path` is a file, `recursive_mode` will be ignored and events will be delivered only
+    /// for the file.
+    ///
+    /// On some platforms, if the `path` is renamed or removed while being watched, behaviour may
+    /// be unexpected. See discussions in [#165] and [#166]. If less surprising behaviour is wanted
+    /// one may non-recursively watch the _parent_ directory as well and manage related events.
+    ///
+    /// [#165]: https://github.com/notify-rs/notify/issues/165
+    /// [#166]: https://github.com/notify-rs/notify/issues/166
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: Box<WatchFilterFn>,
+    ) -> Result<()>;
 
     /// Stop watching a path.
     ///

--- a/notify/src/lib.rs
+++ b/notify/src/lib.rs
@@ -166,7 +166,7 @@
 pub use config::{Config, RecursiveMode};
 pub use error::{Error, ErrorKind, Result};
 pub use notify_types::event::{self, Event, EventKind};
-use std::path::Path;
+use std::{path::Path, sync::Arc};
 
 pub(crate) type Receiver<T> = std::sync::mpsc::Receiver<T>;
 pub(crate) type Sender<T> = std::sync::mpsc::Sender<T>;
@@ -287,7 +287,36 @@ pub enum WatcherKind {
     NullWatcher,
 }
 
-type WatchFilterFn = dyn Fn(&Path) -> bool + Send;
+type FilterFn = dyn Fn(&Path) -> bool + Send + Sync;
+/// Path filter to limit what gets watched.
+#[derive(Clone)]
+pub struct WatchFilter(Option<Arc<FilterFn>>);
+
+impl std::fmt::Debug for WatchFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("WatchFilterFn")
+            .field(&self.0.as_ref().map_or("no filter", |_| "filter fn"))
+            .finish()
+    }
+}
+
+impl WatchFilter {
+    /// A filter that accepts any path, use to watch all paths.
+    pub fn accept_all() -> WatchFilter {
+        WatchFilter(None)
+    }
+
+    /// A fitler to limit the paths that get watched.
+    ///
+    /// Only paths for which `filter` returns `true` will be watched.
+    pub fn with_filter(filter: Arc<FilterFn>) -> WatchFilter {
+        WatchFilter(Some(filter))
+    }
+
+    fn should_watch(&self, path: &Path) -> bool {
+        self.0.as_ref().map_or(true, |f| f(path))
+    }
+}
 
 /// Type that can deliver file activity notifications
 ///
@@ -315,7 +344,7 @@ pub trait Watcher {
     /// [#165]: https://github.com/notify-rs/notify/issues/165
     /// [#166]: https://github.com/notify-rs/notify/issues/166
     fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
-        self.watch_filtered(path, recursive_mode, Box::new(|_| true))
+        self.watch_filtered(path, recursive_mode, WatchFilter::accept_all())
     }
 
     /// Begin watching a new path, filtering out sub-paths by name.
@@ -337,7 +366,7 @@ pub trait Watcher {
         &mut self,
         path: &Path,
         recursive_mode: RecursiveMode,
-        watch_filter: Box<WatchFilterFn>,
+        watch_filter: WatchFilter,
     ) -> Result<()>;
 
     /// Stop watching a path.

--- a/notify/src/null.rs
+++ b/notify/src/null.rs
@@ -4,7 +4,7 @@
 
 use crate::Config;
 
-use super::{RecursiveMode, Result, Watcher};
+use super::{RecursiveMode, Result, WatchFilterFn, Watcher};
 use std::path::Path;
 
 /// Stub `Watcher` implementation
@@ -14,7 +14,12 @@ use std::path::Path;
 pub struct NullWatcher;
 
 impl Watcher for NullWatcher {
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> Result<()> {
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        watch_filter: Box<WatchFilterFn>,
+    ) -> Result<()> {
         Ok(())
     }
 

--- a/notify/src/null.rs
+++ b/notify/src/null.rs
@@ -4,7 +4,7 @@
 
 use crate::Config;
 
-use super::{RecursiveMode, Result, WatchFilterFn, Watcher};
+use super::{RecursiveMode, Result, WatchFilter, Watcher};
 use std::path::Path;
 
 /// Stub `Watcher` implementation
@@ -18,7 +18,7 @@ impl Watcher for NullWatcher {
         &mut self,
         path: &Path,
         recursive_mode: RecursiveMode,
-        watch_filter: Box<WatchFilterFn>,
+        watch_filter: WatchFilter,
     ) -> Result<()> {
         Ok(())
     }

--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -4,7 +4,7 @@
 //! Rust stdlib APIs and should work on all of the platforms it supports.
 
 use crate::{
-    unbounded, Config, Error, EventHandler, Receiver, RecursiveMode, Sender, WatchFilterFn, Watcher,
+    unbounded, Config, Error, EventHandler, Receiver, RecursiveMode, Sender, WatchFilter, Watcher,
 };
 use std::{
     collections::HashMap,
@@ -641,7 +641,7 @@ impl Watcher for PollWatcher {
         &mut self,
         path: &Path,
         recursive_mode: RecursiveMode,
-        _watch_filter: Box<WatchFilterFn>,
+        _watch_filter: WatchFilter,
     ) -> crate::Result<()> {
         self.watch_inner(path, recursive_mode);
 

--- a/notify/src/poll.rs
+++ b/notify/src/poll.rs
@@ -3,7 +3,9 @@
 //! Checks the `watch`ed paths periodically to detect changes. This implementation only uses
 //! Rust stdlib APIs and should work on all of the platforms it supports.
 
-use crate::{unbounded, Config, Error, EventHandler, Receiver, RecursiveMode, Sender, Watcher};
+use crate::{
+    unbounded, Config, Error, EventHandler, Receiver, RecursiveMode, Sender, WatchFilterFn, Watcher,
+};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
@@ -635,7 +637,12 @@ impl Watcher for PollWatcher {
         Self::new(event_handler, config)
     }
 
-    fn watch(&mut self, path: &Path, recursive_mode: RecursiveMode) -> crate::Result<()> {
+    fn watch_filtered(
+        &mut self,
+        path: &Path,
+        recursive_mode: RecursiveMode,
+        _watch_filter: Box<WatchFilterFn>,
+    ) -> crate::Result<()> {
         self.watch_inner(path, recursive_mode);
 
         Ok(())


### PR DESCRIPTION
Base PR: https://github.com/notify-rs/notify/pull/632

This adds implementation for:
- FSEventWatcher (Mac)
- INotifyWatcher (Linux)
- ReadDirectoryChangesWatcher (Windows) -- this was not included in the original PR. I had to implement it myself 😅 Verified it does compile on Windows

It doesn't include filter implementation for PollWatcher or KqueueWatcher since these are not used for any major OS. But they should still compile